### PR TITLE
Add optionally run playwright tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,7 +65,7 @@ steps:
       sed -i "s/__api_url__/\/server/g" dist/*.js
       firebase deploy --project $PROJECT_ID --only hosting
 
-  # Optionally run tests, confirming deployment
+  # Optionally run tests, confirming deployment (run with '--substitutions=_RUN_TESTS=yes')
   - id: "test deployment"
     name: python:3.10-slim
     dir: provisioning

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -65,6 +65,23 @@ steps:
       sed -i "s/__api_url__/\/server/g" dist/*.js
       firebase deploy --project $PROJECT_ID --only hosting
 
+  # Optionally run tests, confirming deployment
+  - id: "test deployment"
+    name: python:3.10-slim
+    dir: provisioning
+    script: |
+        #!/bin/bash
+        if [ -z $_RUN_TESTS ]; then
+          echo "_RUN_TESTS not defined, so not running tests."
+          exit 0
+        fi
+
+        python -m pip install -r test/requirements.txt
+        playwright install-deps
+        playwright install
+        python -m pytest
+
+
 timeout: 1800s
 
 substitutions:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -69,6 +69,8 @@ steps:
   - id: "test deployment"
     name: python:3.10-slim
     dir: provisioning
+    env:
+        - _RUN_TESTS=$_RUN_TESTS
     script: |
         #!/bin/bash
         if [ -z $_RUN_TESTS ]; then
@@ -86,3 +88,4 @@ timeout: 1800s
 
 substitutions:
   _REGION: us-central1
+  _RUN_TESTS: ""

--- a/docs/admin/testing-changes.md
+++ b/docs/admin/testing-changes.md
@@ -33,6 +33,7 @@ git push -u origin ${USER}-${BRANCH_NAME}
 1. In Cloud Build, go to [Triggers](https://console.cloud.google.com/cloud-build/triggers?project=avocano-preview) and click "Run". 
 1. In the "Run trigger" side panel, enter the branch name just created. 
    * This should auto-populate after removing the default "main" value. 
+1. Populate the `_RUN_TESTS` variable (any value will do) to also run playwright tests. 
 1. Click **Run trigger**. 
 
 

--- a/provisioning/automation/README.md
+++ b/provisioning/automation/README.md
@@ -2,7 +2,9 @@
 
 This folder is for meta automation. 
 
-TODO(glasnt) describe integration test setup. 
+This folder defines the tests and configurations to test deployments that themselves create new projects. 
+
+## Setup
 
 Run once:
  * `admin-project-setup.sh $FOLDER_ID`
@@ -10,8 +12,10 @@ Run once:
 
 Run periodically: 
 
- * `gcloud builds submit [--config cloudbuild.yaml]`
+ * `gcloud builds submit --config provisioning/automation/cloudbuild.yaml`
     - runs `project-setup.sh` to create a new project
-    - runs `deploy.cloudbuild.yaml` to create a new deployment in that project.
-    - runs `TODO` to test project
-    - deletes project.
+    - runs `deploy.cloudbuild.yaml`, which runs the same `bash setup.sh` as usual.
+    - runs `test.cloudbuild.yaml`, which runs client tests
+    - deletes project, if all other steps succeeded.
+
+

--- a/provisioning/automation/cloudbuild.yaml
+++ b/provisioning/automation/cloudbuild.yaml
@@ -27,19 +27,8 @@ steps:
         "--config=$_CLOUDBUILD_CONFIG",
         "--timeout=1500",
         "--project=$_CI_PROJECT",
+        "--substitutions=$_RUN_TESTS=yes"
       ]
-
-  - id: "test"
-    name: python:3.10-slim
-    dir: provisioning
-    env: ["CI_PROJECT=${_CI_PROJECT}"]
-    script: |
-        #!/bin/bash
-        python -m pip install -r test/requirements.txt
-        playwright install-deps  
-        playwright install
-        python -m pytest
-
 
   - id: "cleanup"
     name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"

--- a/provisioning/automation/test.cloudbuild.yaml
+++ b/provisioning/automation/test.cloudbuild.yaml
@@ -1,26 +1,12 @@
 steps:
 
-  # Only run tests. Useful for iterative testing. 
+  # Only run tests against the current project
   - id: "test"
     name: python:3.10-slim
     dir: provisioning
-    env: ["CI_PROJECT=${_CI_PROJECT}"]
     script: |
         #!/bin/bash
         python -m pip install -r test/requirements.txt
         playwright install-deps  
         playwright install
         python -m pytest
-
-
-options:
-  dynamic_substitutions: true
-  machineType: "E2_HIGHCPU_8"
-
-logsBucket: ${PROJECT_ID}-buildlogs
-serviceAccount: projects/${PROJECT_ID}/serviceAccounts/ci-serviceaccount@avocano-admin.iam.gserviceaccount.com
-
-substitutions:
-  _CI_PROJECT: "avocano-ephemeral-${BUILD_ID:0:8}"
-
-timeout: "1500s"

--- a/provisioning/server.update.sh
+++ b/provisioning/server.update.sh
@@ -25,4 +25,4 @@ gcloud builds submit --config provisioning/server.cloudbuild.yaml
 gcloud builds submit --config provisioning/terraform.cloudbuild.yaml
 
 # Run database migration job
-gcloud beta run jobs execute database-migrate --region $REGION
+gcloud beta run jobs execute migrate --region $REGION

--- a/provisioning/test/README.md
+++ b/provisioning/test/README.md
@@ -1,18 +1,34 @@
-# Provisioing Tests
+# Provisioning Tests
 
-Tests that are run against a deployment to confirm it works. 
+These tests are designed to be run against a deployment. 
 
-TODO(glasnt) describe. 
+They are either run against the current project, or a defined project (using the `CI_PROJECT` value)
 
+
+## Test scope
+
+These tests use [playwright](https://playwright.dev/), and automate the clicking of website buttons to test client deployments. 
+
+There are also other tests, see `test/` for details. 
 
 ## Local dev
 
+Install the dependencies
+
 ```
-export CI_PROJECT=[projectid]
+python -m pip install -r test/requirements.txt
+playwright install-deps  
+playwright install
+```
+
+Then run the tests: 
+
+```
 python -m pytest
 ```
 
-`googleapiclient.discovery` requires authentication, so setup a dedicated service account:
+
+`googleapiclient.discovery` requires authentication, so you may need to setup a dedicated service account:
 
 ```
 gcloud iam service-accounts create robot-account \


### PR DESCRIPTION
## Description

This adds a step to the global `cloudbuild.yaml` to optionally run playwright tests. 

`gcloud builds submit` still runs, and will add 00:00:03 to tests just to confirm the flag isn't set. 

But if you run `gcloud builds submit --substitutions _RUN_TESTS=yes`, ~2 minutes is added to tests that will validate deployments. 

This flag can be run by admins on infra automation, and nightly tests, without affecting user deployments. 
