### PR TITLE
fix(issue-25): tiny prevent default fix when a product is purchased

### DIFF
--- a/client/src/components/product-item.js
+++ b/client/src/components/product-item.js
@@ -82,7 +82,10 @@ export class ProductItem extends LitElement {
    * 'Purchase' the product, but display to
    * user that this is in fact a fake product
    */
-  async buyProduct() {
+  async buyProduct(event) {
+    if (event) {
+      event.preventDefault();
+    }
     if (this.state.count > 0) {
       await buyProduct(this.productItem?.id, () => {
         this.state.count--;


### PR DESCRIPTION
## Description

**Fixes:** #25 

**To reproduce:**
Originally, if a product (i.e `/product/4`) was bought that is not the main product at root (`/`) - you'll be suddenly redirected to root. 

**To ensure this has been resolved:**
* Check this PR out
* Select product from purchase list `/product/{id}`
* Click `Buy` button and verify that you are not redirected and that an Oops modal pops up. Product count should also decrement after every click.


## Checklist
- [x] Added steps to reproduce the changes in this pull request
- [x] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
