### PR TITLE
[no merge] Integration tests

### DIFF
--- a/provisioning/automation/cloudbuild.yaml
+++ b/provisioning/automation/cloudbuild.yaml
@@ -20,8 +20,7 @@ steps:
         "submit",
         "--config=$_CLOUDBUILD_CONFIG",
         "--timeout=1500",
-        "--project=$_CI_PROJECT",
-        "--substitutions=$_RUN_TESTS=yes"
+        "--project=$_CI_PROJECT"
       ]
 
   - id: "cleanup"

--- a/provisioning/automation/deploy.cloudbuild.yaml
+++ b/provisioning/automation/deploy.cloudbuild.yaml
@@ -4,6 +4,8 @@ steps:
   # to kickstart the build within the scope of that project.
   - id: "deploy"
     name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
+    env: 
+    - RUN_TESTS_CONFIG=",_RUN_TESTS=yes"
     script: |
       #!/bin/bash
       bash setup.sh

--- a/provisioning/automation/deploy.cloudbuild.yaml
+++ b/provisioning/automation/deploy.cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
   - id: "deploy"
     name: "gcr.io/google.com/cloudsdktool/cloud-sdk:slim"
     env: 
-    - RUN_TESTS_CONFIG=",_RUN_TESTS=yes"
+    - 'RUN_TESTS_CONFIG=,_RUN_TESTS=yes'
     script: |
       #!/bin/bash
       bash setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -60,7 +60,7 @@ quiet gsutil iam ch \
         gs://$TFSTATE_BUCKET
 
 aecho "Running Cloud Build"
-gcloud builds submit --substitutions _REGION=${REGION}
+gcloud builds submit --substitutions _REGION=${REGION}${RUN_TESTS_CONFIG}
 
 aecho "Setup database"
 gcloud beta run jobs execute setup --wait --region $REGION


### PR DESCRIPTION
This should have allowed integration tests to run the client tests

However, this is for integration tests, where the tests are run after the end of the root `cloudbuild.yaml`, but before the server setup, so the tests fail as there's no data in the api. 

Having `_RUN_TESTS` works for nightly checks, where the database is already populated

Instead, I'll create a change to add client testing specifically to the end of the automation testing, as opposed to firing the optional step in the main cloudbuild.yaml

(Yes, this could be a whole lot cleaner.)
