### PR TITLE
Update PR template to enable automatching

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 
-**Fixes:** #<ISSUE-NUMBER>
+Fixes #<ISSUE-NUMBER>
 
 **Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.
 


### PR DESCRIPTION
## Description

PR #67 didn't automatically close #66. The PR included: 

```
**Fixes**: #66 
```

I'm not sure if it's the formatting or the `:`, but this didn't automatically match. [GitHub Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) say it must be in the form `KEYWORD #ISSUE-NUMBER`, so remove both formatting and `:`. 
