### PR TITLE
Client docs: s/npm build/npm run build

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -33,7 +33,7 @@ Install, build, and start client.
 # Install app dependencies
 npm i
 # Bundle the app
-npm build
+npm run build
 # Runs the app locally!
 npm run start
 ```


### PR DESCRIPTION
Running `npm build` in my client directory results in:

```
➜  client git:(main) ✗ npm build

Unknown command: "build"

Did you mean this?
    npm run build # run the "build" package script

To see a list of supported npm commands, run:
  npm help
```

But `npm run build` works 👍 

```
➜  client git:(main) ✗ npm run build

> avocano-app@0.0.1 build
> rimraf dist && rollup -c rollup.config.js


404.html → dist...
created dist in 8ms

index.html → dist...

The service worker file was written to dist/sw.js
The service worker will precache 4 URLs, totaling 138 kB.

created dist in 1.8s
```

## Description

Fixes #<ISSUE-NUMBER>

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
