### PR TITLE
docs: replace Google internal URL with the public one

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -9,7 +9,7 @@ This client app uses [Lit](https://lit.dev/) front-end and [open-wc](https://ope
 - **Framework:** ⚙️ [Lit](https://lit.dev/)
 - **Scaffolding:** 🏗️ [open-wc](https://open-wc.org/)
 - **Bundler:** 🖇️ [Rollup](https://rollupjs.org/)
-- **Hosting:** 🔥 [Firebase](https://firebase.corp.google.com/)
+- **Hosting:** 🔥 [Firebase](https://firebase.google.com/)
 
 ## Requirements
 


### PR DESCRIPTION
## Description

Fixes #124

Hello, I found publicly inaccessible URLs in the docs. Thanks. 🙂 

To check the change, try accessing the new URL.

## Checklist
- [x] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
