### PR TITLE
chore(deps): group otel library updates from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-   ":disableDependencyDashboard"
+    ":disableDependencyDashboard"
   ],
   "rangeStrategy": "auto",
   "packageRules": [
@@ -15,6 +15,10 @@
         "enabled": true,
         "recreateClosed": true
       }
+    },
+    {
+      "groupName": "OpenTelemetry",
+      "matchPackagePrefixes": ["opentelemetry-"]
     }
   ]
 }


### PR DESCRIPTION
## Description

OTel libraries are released together, and include co-dependent changes. This
should help us avoid the dependency issues seen earlier in emblem.

