### PR TITLE
Update renovate: Group OTel & Playwright, & unlimited open PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-   ":disableDependencyDashboard"
+    ":disableDependencyDashboard",
+    ":prConcurrentLimitNone"
   ],
   "rangeStrategy": "auto",
   "packageRules": [
@@ -15,6 +16,17 @@
         "enabled": true,
         "recreateClosed": true
       }
+    },
+    {
+      "description": "Playright dependencies must be kept in sync",
+      "groupName": "Playwright",
+      "matchPackageNames": ["playwright", "@playwright/test", "mcr.microsoft.com/playwright"] 
+    },
+    {
+      "description": "Python OpenTelemetry dependencies must be kept in sync",
+      "groupName": "OpenTelemetry",
+      "matchLanguages": ["python"],
+      "matchPackagePrefixes": ["opentelemetry-"]
     }
   ]
 }


### PR DESCRIPTION
## Description

* Playwright dependencies must be kept in close synchronization
* OpenTelemetry Python libraries must be kept in close sync
* Renovate by default will only open 10 PRs, without the dependency dashboard issue it's hard to see if there are more. This change includes a tweak allowing renovate to open as many PRs as it thinks are necessary, which improves our PR-based visibility into the amount of update work to be done.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
