### PR TITLE
feat: Add container annotations for title, description, and purchase_mode

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -22,10 +22,14 @@ FROM gcr.io/$PROJECT_ID/firebase
 # Override with "--build-arg AVOCANO_PURCHASE_MODE=cart"
 ARG AVOCANO_PURCHASE_MODE=""
 
+LABEL org.opencontainers.artifact.title="Avocano Client Deployer" \
+      org.opencontainers.artifact.description="Deploy pre-built frontend to Firebase Hosting" \
+      dev.avocano.purchase_mode="${AVOCANO_PURCHASE_MODE}"
+
 COPY package*.json ./
 RUN npm i
 COPY . ./
-RUN npm run build 
+RUN npm run build
 
 RUN npm install -g json
 ENTRYPOINT ./docker-deploy.sh


### PR DESCRIPTION
## Description

This advances work on #147 for the client container by adding image labels, or annotations, to the client dockerfile.

Annotations such as this are not particularly surfaced in Cloud products, but if you have the container image you can examine with docker inspect.

![Screenshot 2023-04-07 at 3 34 09 PM](https://user-images.githubusercontent.com/283489/230687137-d87d4ffd-c7ff-43f0-9518-a7894294dcf0.png)

A more targeted inspection can pull just the annotation we want out:

```
docker inspect --format='{{index .Config.Labels "dev.avocano.purchase_mode"}}' avocano-client-image
cart
```

I would have preferred to extend this further with Avocano version and build timestamp, but those would require adding more build args and I've deliberately made this change least impact.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
