### PR TITLE
chore: re-enable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,12 @@
 {
   "extends": [
     "config:base",
-    ":disableDependencyDashboard",
     ":prConcurrentLimitNone"
   ],
   "rangeStrategy": "auto",
   "packageRules": [
     {
-      "paths": [
+      "matchPaths": [
         "client/"
       ],
       "pinVersions": false,


### PR DESCRIPTION
## Description

Dependency dashboard is how we can investigate and control renovate behavior.
paths is a deprecated property, it should be a non-functional change.

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
