### PR TITLE
Update auto-label.yml: Do not apply ignore-for-release label to chores

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -30,6 +30,7 @@ jobs:
         uses: bcoe/conventional-release-labels@v1
         with:
           type_labels: '{"feat": "type: feature request", "fix": "type: bug", "breaking": "semver: major"}'
+          ignored_types: '[]'
 
   label-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change may not work in practice, it is meant to disable a default behavior of applying an ignore-for-release label to chore PRs.

https://github.com/bcoe/conventional-release-labels/blob/main/action.yml#L14

## Description

Fixes #<ISSUE-NUMBER>

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
