### PR TITLE
chore: use pull_request_target for GHA commenting workflow

### DIFF
--- a/.github/workflows/review-warning.yml
+++ b/.github/workflows/review-warning.yml
@@ -21,7 +21,7 @@ name: review-warning
 # files moved into the job logic to differentiate messaging.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
     paths:
       - '.github/workflows/release-major-tags.yml'


### PR DESCRIPTION
## Description

Fix the review-warning workflow error found in #219. If this works, port the change to tdpwa

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
