### PR TITLE
testing: terraform linter exit code fix

### DIFF
--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Analysing the code with terraform
         timeout-minutes: 5
         run: |
-          terraform fmt -check
+          terraform fmt -check -diff

--- a/.github/workflows/lint-terraform.yml
+++ b/.github/workflows/lint-terraform.yml
@@ -19,6 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3
       - uses: hashicorp/setup-terraform@633666f66e0061ca3b725c73b2ec20cd13a8fdd1 # v2
+        with:
+          # Workaround for https://github.com/hashicorp/setup-terraform/issues/328
+          terraform_wrapper: false
       - name: Analysing the code with terraform
         timeout-minutes: 5
         run: |

--- a/provisioning/terraform/apis.tf
+++ b/provisioning/terraform/apis.tf
@@ -17,7 +17,7 @@ locals {
 
 resource "google_project_service" "enabled" {
   for_each                   = toset(local.services)
-  project                    = var.project_id
+  project     = var.project_id
   service                    = each.value
   disable_dependent_services = true
   disable_on_destroy         = false

--- a/provisioning/terraform/apis.tf
+++ b/provisioning/terraform/apis.tf
@@ -17,7 +17,7 @@ locals {
 
 resource "google_project_service" "enabled" {
   for_each                   = toset(local.services)
-  project     = var.project_id
+  project                    = var.project_id
   service                    = each.value
   disable_dependent_services = true
   disable_on_destroy         = false


### PR DESCRIPTION
This should cause the `terraform fmt` to correctly exit non-zero when
encountering a tf formatting error.

As suggested by @chgans

Part of #270

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [x] Please **merge** this PR for me once it is approved.
