### PR TITLE
fix: restore client annotation to cloud run service

### DIFF
--- a/provisioning/terraform/service.tf
+++ b/provisioning/terraform/service.tf
@@ -1,6 +1,8 @@
 resource "google_cloud_run_v2_service" "server" {
   name     = var.service_name
   location = var.region
+  client   = "terraform"
+
   template {
     service_account = google_service_account.server.email
     containers {


### PR DESCRIPTION
## Description

Fixes #257

From the original annotations pre #240: 

* Add client ("Arbitrary identifier for the API client.") in this PR
* Cloud SQL was moved to volumes
* maxScale is optional, was using the default value


## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.

## Post merge and verification

- [ ] Apply to https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp
