### PR TITLE
fix: restore startup probe, 1s period

### DIFF
--- a/provisioning/terraform/service.tf
+++ b/provisioning/terraform/service.tf
@@ -30,6 +30,15 @@ resource "google_cloud_run_v2_service" "server" {
         name  = "OTEL_TRACES_EXPORTER"
         value = "gcp_trace"
       }
+      startup_probe {
+        http_get {
+          path = "/ready"
+        }
+        period_seconds        = 1
+        initial_delay_seconds = 0
+        timeout_seconds       = 1
+        failure_threshold     = 10
+      }
       liveness_probe {
         http_get {
           path = "/healthy"


### PR DESCRIPTION
## Description

Reference #74 

Restores the startup probe in #225, with better behaving configuration values. 

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.


## Post merge and verification

- [ ] Apply to https://github.com/GoogleCloudPlatform/terraform-dynamic-python-webapp