### PR TITLE
bug: correct csrf async issue

### DIFF
--- a/client/src/utils/fetch.js
+++ b/client/src/utils/fetch.js
@@ -19,7 +19,7 @@ const baseRequest = {
   credentials: 'include',
 };
 
-const _getAPI = async (uri) => {
+const _getAPI = async uri => {
   const { API_URL } = getConfig();
 
   let url = `${API_URL}/${uri}`;
@@ -67,8 +67,7 @@ const _getAPI = async (uri) => {
   }
 
   return data;
-}
-
+};
 
 export const getProduct = async productId => {
   return _getAPI(`products/${productId}`);
@@ -79,7 +78,7 @@ export const getActiveProduct = async () => {
 };
 
 export const buyProduct = async (productId, callback) => {
-  let uri = `products/${productId}/purchase/`
+  let uri = `products/${productId}/purchase/`;
   const { API_URL } = getConfig();
 
   let url = `${API_URL}/${uri}`;

--- a/client/src/utils/fetch.js
+++ b/client/src/utils/fetch.js
@@ -19,7 +19,7 @@ const baseRequest = {
   credentials: 'include',
 };
 
-async function _getAPI(uri) {
+const _getAPI = async (uri) => {
   const { API_URL } = getConfig();
 
   let url = `${API_URL}/${uri}`;
@@ -69,25 +69,6 @@ async function _getAPI(uri) {
   return data;
 }
 
-async function _postAPI(uri, callback) {
-  const { API_URL } = getConfig();
-
-  let url = `${API_URL}/${uri}`;
-  try {
-    const csrfToken = _getAPI('csrf_token');
-
-    await fetch(url, {
-      method: 'POST',
-      headers: { 'X-CSRFToken': csrfToken },
-      ...baseRequest,
-    });
-    callback && callback(); // callbacks handle error message parsing directly.
-  } catch (error) {
-    console.error(error);
-  }
-
-  return { data };
-}
 
 export const getProduct = async productId => {
   return _getAPI(`products/${productId}`);
@@ -98,7 +79,24 @@ export const getActiveProduct = async () => {
 };
 
 export const buyProduct = async (productId, callback) => {
-  _postAPI(`products/${productId}/purchase/`, callback);
+  let uri = `products/${productId}/purchase/`
+  const { API_URL } = getConfig();
+
+  let url = `${API_URL}/${uri}`;
+  try {
+    const token = await _getAPI('csrf_token');
+
+    await fetch(url, {
+      method: 'POST',
+      headers: { 'X-CSRFToken': token.csrfToken },
+      ...baseRequest,
+    });
+    callback && callback(); // callbacks handle error message parsing directly.
+  } catch (error) {
+    console.error(error);
+  }
+
+  return { data };
 };
 
 export const getProductTestimonials = async productId => {
@@ -120,11 +118,34 @@ export const getSiteConfig = async () => {
 };
 
 export const checkout = async payload => {
+  const { API_URL } = getConfig();
+  let checkoutStatus;
+  let errors;
+
   if (payload?.items?.length) {
-    return _postAPI('checkout/');
+    try {
+      // Retrieve csrf token from server
+      const token = await _getAPI('csrf_token');
+
+      // Submit form payload and pass back csrf token
+      const response = await fetch(`${API_URL}/checkout`, {
+        method: 'POST',
+        headers: { 'X-CSRFToken': token.csrfToken },
+        body: JSON.stringify(payload),
+        ...baseRequest,
+      });
+      checkoutStatus = await response.json();
+    } catch (error) {
+      errors = [error];
+    }
   } else {
-    let errorMessage = 'Insufficient information to process checkout.';
-    console.log(errorMessage);
-    return [{ message: errorMessage }];
+    errors = [{ message: 'Insufficient information to process checkout.' }];
   }
+
+  if (errors) {
+    console.error(errors);
+    checkoutStatus = { errors };
+  }
+
+  return checkoutStatus;
 };

--- a/server/store/views.py
+++ b/server/store/views.py
@@ -71,7 +71,7 @@ class ProductViewSet(viewsets.ModelViewSet):
             raise ProductPurchaseException()
 
         serializer = ProductSerializer(product)
-        return Response(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
 
 class ActiveProductViewSet(viewsets.ViewSet):
@@ -147,7 +147,7 @@ def checkout(request):
 
     response = CheckoutSerializer(data={"status": "complete", "items": items})
     response.is_valid()
-    return JsonResponse(response.data)
+    return JsonResponse(response.data, status=status.HTTP_201_CREATED)
 
 
 def csrf_token(request):


### PR DESCRIPTION
## Description

Addresses #195 

Reverts some of #290 to keep separate functions for callback post and data post, fixes 404 error on `checkout/` (should be `checkout`, no slash), and correct issue where `csrfToken` returns `[object Promise]` and not the value of the token. 

**Note:** Before submitting a pull request, please open an issue for discussion if you are not associated with Google.

## Checklist
- [ ] Added steps to reproduce the changes in this pull request
- [ ] Added relevant testing in this pull request
- [ ] Please **merge** this PR for me once it is approved.
