### PR TITLE
fix: Remove .txt files from requiring licence headers

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -38,4 +38,3 @@ sourceFileExtensions:
   - "yml"
   - "py"
   - "html"
-  - "txt"


### PR DESCRIPTION
## Description

Fixes check failures on #309

version.txt is parsed directly as a version number, and having licence headers on requirements*.txt files is unusual

Therefore, this these are all the .txt files in the repo, remove the requirement for txt files to have licence headers. 
