### PR TITLE
feat: handle deterministic URLs

### DIFF
--- a/server/avocano_api/cloudrun_helpers.py
+++ b/server/avocano_api/cloudrun_helpers.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 from google.cloud import run_v2
 
@@ -68,19 +69,22 @@ def _service_name():
     return service
 
 
-def _service_url(project, region, service):
+def _service_urls(project, region, service):
     try:
         client = run_v2.ServicesClient()
         fqname = f"projects/{project}/locations/{region}/services/{service}"
         request = run_v2.GetServiceRequest(name=fqname)
         response = client.get_service(request=request)
-        return response.uri
+
+        ## This will return multiple values
+        annotations = response["metadata"]["annotations"]["run.googleapis.com/urls"]
+        return json.loads(annotations)
     except google.api_core.exceptions.GoogleAPICallError as e:
         raise MetadataError(f"Could not determine service url. Error: {e}")
 
 
-def get_service_url():
-    return _service_url(_project_id(), _region(), _service_name())
+def get_service_urls():
+    return _service_urls(_project_id(), _region(), _service_name())
 
 
 def get_project_id():

--- a/server/avocano_api/cloudrun_helpers.py
+++ b/server/avocano_api/cloudrun_helpers.py
@@ -85,7 +85,7 @@ def _service_url(project, region, service):
         raise MetadataError(f"Could not determine service url. Error: {e}")
 
 
-def get_service_urls():
+def get_service_url():
     return _service_url(_project_id(), _region(), _service_name())
 
 

--- a/server/avocano_api/cloudrun_helpers.py
+++ b/server/avocano_api/cloudrun_helpers.py
@@ -69,7 +69,7 @@ def _service_name():
     return service
 
 
-def _service_urls(project, region, service):
+def _service_url(project, region, service):
     try:
         client = run_v2.ServicesClient()
         fqname = f"projects/{project}/locations/{region}/services/{service}"
@@ -78,13 +78,15 @@ def _service_urls(project, region, service):
 
         ## This will return multiple values
         annotations = response["metadata"]["annotations"]["run.googleapis.com/urls"]
-        return json.loads(annotations)
+
+        ## Return a comma-separated list
+        return ",".join(json.loads(annotations))
     except google.api_core.exceptions.GoogleAPICallError as e:
         raise MetadataError(f"Could not determine service url. Error: {e}")
 
 
 def get_service_urls():
-    return _service_urls(_project_id(), _region(), _service_name())
+    return _service_url(_project_id(), _region(), _service_name())
 
 
 def get_project_id():

--- a/server/avocano_api/settings.py
+++ b/server/avocano_api/settings.py
@@ -101,7 +101,9 @@ if not CLOUDRUN_SERVICE_URLS:
 
 if CLOUDRUN_SERVICE_URLS:
     # Setup as we are running in Cloud Run & Firebase
-    ALLOWED_HOSTS = [urlparse(url).netloc for urls in CLOUDRUN_SERVICE_URLS] + ["127.0.0.1"]
+    ALLOWED_HOSTS = [urlparse(url).netloc for url in CLOUDRUN_SERVICE_URLS] + [
+        "127.0.0.1"
+    ]
 
     # Firebase hosting has multiple default URLs, so add those as well.
     project_id = get_project_id()

--- a/server/avocano_api/settings.py
+++ b/server/avocano_api/settings.py
@@ -22,7 +22,7 @@ from urllib.parse import urlparse
 
 import environ
 
-from .cloudrun_helpers import MetadataError, get_service_url, get_project_id
+from .cloudrun_helpers import MetadataError, get_service_urls, get_project_id
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -90,18 +90,18 @@ local_hosts = ["http://localhost:8000", "http://localhost:8081"]
 cloudshell_host = "https://*.cloudshell.dev"
 
 # Used to identify the host of the deployed service
-CLOUDRUN_SERVICE_URL = env("CLOUDRUN_SERVICE_URL", default=None)
+CLOUDRUN_SERVICE_URLS = env("CLOUDRUN_SERVICE_URLS", default=None)
 
 # If the Cloud Run service isn't defined, try dynamically retrieving it.
-if not CLOUDRUN_SERVICE_URL:
+if not CLOUDRUN_SERVICE_URLS:
     try:
-        CLOUDRUN_SERVICE_URL = get_service_url()
+        CLOUDRUN_SERVICE_URLS = get_service_urls()
     except MetadataError:
         pass
 
-if CLOUDRUN_SERVICE_URL:
+if CLOUDRUN_SERVICE_URLS:
     # Setup as we are running in Cloud Run & Firebase
-    ALLOWED_HOSTS = [urlparse(CLOUDRUN_SERVICE_URL).netloc, "127.0.0.1"]
+    ALLOWED_HOSTS = [urlparse(url).netloc for urls in CLOUDRUN_SERVICE_URLS] + ["127.0.0.1"]
 
     # Firebase hosting has multiple default URLs, so add those as well.
     project_id = get_project_id()
@@ -120,7 +120,7 @@ if CLOUDRUN_SERVICE_URL:
         f"https://{firebase_site_id}.firebaseapp.com",
     ]
 
-    CSRF_TRUSTED_ORIGINS = [CLOUDRUN_SERVICE_URL] + local_hosts + firebase_hosts
+    CSRF_TRUSTED_ORIGINS = CLOUDRUN_SERVICE_URLS + local_hosts + firebase_hosts
     SECURE_SSL_REDIRECT = True
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 else:


### PR DESCRIPTION
## Description

Fixes #493

Changes CLOUDRUN_SERVICE_URL to support a list of URLs from the "run.googleapis.com/urls" annotation for CSRF. 

Opted to not pluralise this URL, but update it to presume it's a string, with possible comma separation. 

This also may not require `run.viewer` on the server service account any more, which will need to be updated with the tf updates. 

## Checklist
- [x] Please **merge** this PR for me once it is approved.
