### PR TITLE
fix: use metadata-aware client sdk

### DIFF
--- a/server/avocano_api/cloudrun_helpers.py
+++ b/server/avocano_api/cloudrun_helpers.py
@@ -16,9 +16,9 @@
 
 import json
 import os
-from google.cloud import run_v2
 
 import google.auth
+from googleapiclient.discovery import build
 import httpx
 
 ## Dynamically determine the Cloud Run Service URL
@@ -71,13 +71,11 @@ def _service_name():
 
 def _service_url(project, region, service):
     try:
-        client = run_v2.ServicesClient()
         fqname = f"projects/{project}/locations/{region}/services/{service}"
-        request = run_v2.GetServiceRequest(name=fqname)
-        response = client.get_service(request=request)
+        service = build("run", "v1").projects().locations().services().get(name=fqname).execute()
 
         ## This will return multiple values
-        annotations = response["metadata"]["annotations"]["run.googleapis.com/urls"]
+        annotations = service["metadata"]["annotations"]["run.googleapis.com/urls"]
 
         ## Return a comma-separated list
         return ",".join(json.loads(annotations))

--- a/server/avocano_api/cloudrun_helpers.py
+++ b/server/avocano_api/cloudrun_helpers.py
@@ -72,7 +72,14 @@ def _service_name():
 def _service_url(project, region, service):
     try:
         fqname = f"projects/{project}/locations/{region}/services/{service}"
-        service = build("run", "v1").projects().locations().services().get(name=fqname).execute()
+        service = (
+            build("run", "v1")
+            .projects()
+            .locations()
+            .services()
+            .get(name=fqname)
+            .execute()
+        )
 
         ## This will return multiple values
         annotations = service["metadata"]["annotations"]["run.googleapis.com/urls"]

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -18,6 +18,7 @@ gunicorn==23.0.0
 google-cloud-run==0.10.8
 google-auth==2.34.0
 django-storages[google]==1.14.4
+google-api-python-client==2.147.0
 
 # Testing
 pyyaml==6.0.2


### PR DESCRIPTION
## Description

Fixes #497

Service object from google-cloud-run doesn't return metadata dict; but discovery API does. 

Not noticed in validation in #497 because manual e2e testing is required (older infra setup on this repo)
