### PR TITLE
Revert "chore(deps): update python docker tag to v3.13"

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -67,7 +67,7 @@ steps:
   # Use Debian 11 Bullseye until Playwright supports Debian 12 Bookworm
   #   - https://playwright.dev/python/docs/intro#system-requirements
   - id: "test deployment"
-    name: python:3.13-bullseye
+    name: python:3.12-bullseye
     dir: provisioning
     env:
       - _RUN_TESTS=$_RUN_TESTS

--- a/provisioning/automation/cloudbuild.yaml
+++ b/provisioning/automation/cloudbuild.yaml
@@ -42,7 +42,7 @@ steps:
   # Use Debian 11 Bullseye until Playwright supports Debian 12 Bookworm
   #   - https://playwright.dev/python/docs/intro#system-requirements
   - id: "test"
-    name: python:3.13-bullseye
+    name: python:3.12-bullseye
     dir: provisioning
     env: 
       - 'CI_PROJECT=$_CI_PROJECT'


### PR DESCRIPTION
Reverts GoogleCloudPlatform/avocano#517
 
Nested dependencies mean that an older version of greenlet is being installed that isn't building correctly with Python 3.13 (only affects nightly builds, not PR builds). This PR only updated to Python 3.13 for testing, not the main application, so best to keep everything on Python 3.12 for now. 