### PR TITLE
fix: revert pack images to k8s-skaffold version

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,7 +14,7 @@
 
 steps:
   - id: server build
-    name: buildpacksio/pack
+    name: gcr.io/k8s-skaffold/pack
     args:
       - build
       - us-docker.pkg.dev/$PROJECT_ID/containers/server

--- a/provisioning/server.cloudbuild.yaml
+++ b/provisioning/server.cloudbuild.yaml
@@ -16,7 +16,7 @@
 
 steps:
   - id: server build
-    name: buildpacksio/pack
+    name: gcr.io/k8s-skaffold/pack
     args:
       - build
       - us-docker.pkg.dev/$PROJECT_ID/containers/$_IMAGE_NAME

--- a/provisioning/tagged-images.cloudbuild.yaml
+++ b/provisioning/tagged-images.cloudbuild.yaml
@@ -30,7 +30,7 @@ steps:
       - "."
 
   - id: server build
-    name: buildpacksio/pack
+    name: gcr.io/k8s-skaffold/pack
     args:
       - build
       - us-docker.pkg.dev/$PROJECT_ID/containers/$_SERVER_IMAGE_NAME:$TAG_NAME


### PR DESCRIPTION
## Description

Fixes b/484799054

Recently, builds have been failing on this repo due to mismatched versions of Docker (see #684)

This repo uses the OSS version of `pack`, instead of the Cloud Build recommended version, which is an older version pack, but based on isolated testing, doesn't incur the mismatch version error. 

This PR reverts this earlier change #536